### PR TITLE
GEODE-6971: Modified test code to accomodate CQ API changes

### DIFF
--- a/geode-cq/src/upgradeTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscBCDUnitTest.java
+++ b/geode-cq/src/upgradeTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscBCDUnitTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Method;
 import java.net.ConnectException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -300,7 +301,9 @@ public class ClientServerMiscBCDUnitTest extends ClientServerMiscDUnitTestBase {
     Region r = cache.getRegion(Region.SEPARATOR + REGION_NAME2);
     assertNotNull(r);
     CqAttributesFactory cqAttributesFactory = new CqAttributesFactory();
-    cqAttributesFactory.addCqListener(Mockito.mock(CqListener.class));
+    Method method = cqAttributesFactory.getClass().getMethod("addCqListener" , CqListener.class);
+    method.setAccessible(true);
+    method.invoke(cqAttributesFactory, Mockito.mock(CqListener.class));
     final CqQuery cq = cache.getQueryService().newCq("testCQ", "select * from " + r.getFullPath(),
         cqAttributesFactory.create());
     cq.execute();


### PR DESCRIPTION
  * The backwards compatibility tests are failing because the
    tests are 'using' the new api that does not exist in the
    old client classes
  * The workaround is to use reflection to grab the old method
    and execute that directly.

Hello,
I noticed a pr that was failing with some backwards compatibility tests.  I liked the idea for the change and I believe the failure was more due to the way the tests are run.  It executes the latest compiled test code and attempts to run that code on the old clients.  In this case the API has changed so the method it tries to execute doesn't exist.  I think this patch works-around this specific issue (not sure what else might pop up).


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
