### PR TITLE
GEODE-7727: Test of region operations in the face of closed connections

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/tcp/CloseConnectionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/tcp/CloseConnectionTest.java
@@ -1,0 +1,62 @@
+package org.apache.geode.internal.tcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.distributed.internal.ClusterDistributionManager;
+import org.apache.geode.distributed.internal.DistributionImpl;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.cache.CacheTestCase;
+
+public class CloseConnectionTest extends CacheTestCase {
+
+  @Test(timeout = 60_000)
+  public void test() {
+    VM vm0 = VM.getVM(0);
+    VM vm1 = VM.getVM(1);
+
+    // Create a region in each member. VM0 has a proxy region, so state must be in VM1
+    vm0.invoke(() -> {
+      getCache().createRegionFactory(RegionShortcut.REPLICATE_PROXY).create("region");
+    });
+    vm1.invoke(() -> {
+      getCache().createRegionFactory(RegionShortcut.REPLICATE).create("region");
+    });
+
+
+    // Force VM1 to close it's connections.
+    vm1.invoke(() -> {
+      ConnectionTable conTable = getConnectionTable();
+      assertThat(conTable.getNumberOfReceivers()).isEqualTo(2);
+      conTable.closeReceivers(false);
+      assertThat(conTable.getNumberOfReceivers()).isEqualTo(0);
+    });
+
+    // See if VM0 noticed the closed connections. Try to do a couple of region
+    // operations
+    vm0.invoke(() -> {
+      Region<Object, Object> region = getCache().getRegion("region");
+      region.put("1", "1");
+
+      assertThat(region.get("1")).isEqualTo("1");
+    });
+
+    // Make sure connections were reestablished
+    vm1.invoke(() -> {
+      ConnectionTable conTable = getConnectionTable();
+      assertThat(conTable.getNumberOfReceivers()).isEqualTo(2);
+    });
+  }
+
+  private ConnectionTable getConnectionTable() {
+    ClusterDistributionManager cdm =
+        (ClusterDistributionManager) getSystem().getDistributionManager();
+    DistributionImpl distribution = (DistributionImpl) cdm.getDistribution();
+    return distribution.getDirectChannel().getConduit().getConTable();
+  }
+
+
+}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -794,6 +794,10 @@ public class DistributionImpl implements Distribution {
     return result;
   }
 
+  public DirectChannel getDirectChannel() {
+    return directChannel;
+  }
+
 
   /**
    * Insert our own MessageReceiver between us and the direct channel, in order to correctly filter

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/ConnectionTable.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/ConnectionTable.java
@@ -708,7 +708,7 @@ public class ConnectionTable {
    *
    * @param beingSick a test hook to simulate a sick process
    */
-  private void closeReceivers(boolean beingSick) {
+  void closeReceivers(boolean beingSick) {
     synchronized (receivers) {
       for (Iterator it = receivers.iterator(); it.hasNext();) {
         Connection con = (Connection) it.next();

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
@@ -612,7 +612,7 @@ public class TCPConduit implements Runnable {
     }
   }
 
-  private ConnectionTable getConTable() {
+  ConnectionTable getConTable() {
     ConnectionTable result = conTable;
     if (result == null) {
       stopper.checkCancelInProgress(null);


### PR DESCRIPTION
Adding a test for what happens to region operations when a connection is closed
out from under the system. This test hangs without the changes to let the
reader thread keep running.

Fix to test

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
