### PR TITLE
Test of closed connection and fix to input buffer release logic

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/tcp/CloseConnectionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/tcp/CloseConnectionTest.java
@@ -1,0 +1,62 @@
+package org.apache.geode.internal.tcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.distributed.internal.ClusterDistributionManager;
+import org.apache.geode.distributed.internal.DistributionImpl;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.cache.CacheTestCase;
+
+public class CloseConnectionTest extends CacheTestCase {
+
+  @Test(timeout = 60_000)
+  public void sharedSenderShouldRecoverFromClosedSocket() {
+    VM vm0 = VM.getVM(0);
+    VM vm1 = VM.getVM(1);
+
+    // Create a region in each member. VM0 has a proxy region, so state must be in VM1
+    vm0.invoke(() -> {
+      getCache().createRegionFactory(RegionShortcut.REPLICATE_PROXY).create("region");
+    });
+    vm1.invoke(() -> {
+      getCache().createRegionFactory(RegionShortcut.REPLICATE).create("region");
+    });
+
+
+    // Force VM1 to close it's connections.
+    vm1.invoke(() -> {
+      ConnectionTable conTable = getConnectionTable();
+      assertThat(conTable.getNumberOfReceivers()).isEqualTo(2);
+      conTable.closeReceivers(false);
+      assertThat(conTable.getNumberOfReceivers()).isEqualTo(0);
+    });
+
+    // See if VM0 noticed the closed connections. Try to do a couple of region
+    // operations
+    vm0.invoke(() -> {
+      Region<Object, Object> region = getCache().getRegion("region");
+      region.put("1", "1");
+
+      assertThat(region.get("1")).isEqualTo("1");
+    });
+
+    // Make sure connections were reestablished
+    vm1.invoke(() -> {
+      ConnectionTable conTable = getConnectionTable();
+      assertThat(conTable.getNumberOfReceivers()).isEqualTo(2);
+    });
+  }
+
+  private ConnectionTable getConnectionTable() {
+    ClusterDistributionManager cdm =
+        (ClusterDistributionManager) getSystem().getDistributionManager();
+    DistributionImpl distribution = (DistributionImpl) cdm.getDistribution();
+    return distribution.getDirectChannel().getConduit().getConTable();
+  }
+
+
+}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -794,6 +794,10 @@ public class DistributionImpl implements Distribution {
     return result;
   }
 
+  public DirectChannel getDirectChannel() {
+    return directChannel;
+  }
+
 
   /**
    * Insert our own MessageReceiver between us and the direct channel, in order to correctly filter

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -328,6 +328,9 @@ public class Connection implements Runnable {
   /** the buffer used for message receipt */
   private ByteBuffer inputBuffer;
 
+  /** Lock used to protect the input buffer */
+  public final Object inputBufferLock = new Object();
+
   /** the length of the next message to be dispatched */
   private int messageLength;
 
@@ -1507,10 +1510,12 @@ public class Connection implements Runnable {
   }
 
   private void releaseInputBuffer() {
-    ByteBuffer tmp = inputBuffer;
-    if (tmp != null) {
-      inputBuffer = null;
-      getBufferPool().releaseReceiveBuffer(tmp);
+    synchronized (inputBufferLock) {
+      ByteBuffer tmp = inputBuffer;
+      if (tmp != null) {
+        inputBuffer = null;
+        getBufferPool().releaseReceiveBuffer(tmp);
+      }
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/ConnectionTable.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/ConnectionTable.java
@@ -708,7 +708,7 @@ public class ConnectionTable {
    *
    * @param beingSick a test hook to simulate a sick process
    */
-  private void closeReceivers(boolean beingSick) {
+  void closeReceivers(boolean beingSick) {
     synchronized (receivers) {
       for (Iterator it = receivers.iterator(); it.hasNext();) {
         Connection con = (Connection) it.next();

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
@@ -612,7 +612,7 @@ public class TCPConduit implements Runnable {
     }
   }
 
-  private ConnectionTable getConTable() {
+  ConnectionTable getConTable() {
     ConnectionTable result = conTable;
     if (result == null) {
       stopper.checkCancelInProgress(null);


### PR DESCRIPTION
This PR contains two changes that improve the original PR against geode https://github.com/apache/geode/pull/4751.

Adding a test for what happens to region operations when a connection is closed
out from under the system. This test hangs without the changes to let the
reader thread keep running.

Preventing a double release of the input buffer

The releaseInputBuffer method was not thread safe. If it is called
concurrently, it will end up being released twice, which will add the buffer to
to the buffer pool twice. Later, this could result in two threads using the
same buffer, resulting in corruption of the buffer.

With the changes for GEODE-7727, we made it likely that releaseInputBuffer
would be called concurrently. If a member departs, one thread will call
Connection.close. Connection.close will close the socket and call
releaseInputBuffer. However, closing the socket will wake up the reader thread,
which will also call releaseInputBuffer concurrently.

Making releaseInputBuffer thread safe by introducing a lock.

