### PR TITLE
Expose gfshout and gfsherr variables from Gfsh class

### DIFF
--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/shell/Gfsh.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/shell/Gfsh.java
@@ -1171,4 +1171,30 @@ public class Gfsh extends JLineShell {
     }
     return output;
   }
+
+  /**
+   * Set the Gfshout value
+   *
+   * @param out gfsh out stream to be set
+   */
+  public void setGfshout(PrintStream out) {
+    if (out == null) {
+      throw new IllegalArgumentException(
+          "Gfsh out stream can not be set to null.");
+    }
+    gfshout = out;
+  }
+
+  /**
+   * Set the Gfsherr value
+   *
+   * @param err gfsh err stream to be set
+   */
+  public void setGfsherr(PrintStream err) {
+    if (err == null) {
+      throw new IllegalArgumentException(
+          "Gfsh err stream can not be set to null.");
+    }
+    gfsherr = err;
+  }
 }


### PR DESCRIPTION
Gfshout and Gfsherr variables in Gfsh.java can not change now, default to System.out and System.err, improve to make it changeable

ADPPRG-113917 Expose gfshout and gfsherr variables from Gfsh class
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
